### PR TITLE
🐛 correct critical hand eval and ranking bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,29 @@
 
 ## Introduction
 
-This library offers some PHP classes useful for creating a Poker card game:
+This library offers PHP classes for building a Poker card game:
 
-* Game _(needs to be extended)_
-* Player _(needs to be extended)_
-* Hand
-* PokerRank
+* `Game` _(abstract, needs to be extended)_
+* `Player` _(abstract, needs to be extended)_
+* `Hand` — evaluates a poker hand
+* `PokerRank` — identifies the best hand from a set of cards
+
+`Hand` and `PokerRank` work with any number of cards and are not tied to a specific poker variant. `Game::deal()` is configurable for different dealing styles (see Usage). `Game::winner()` assumes a community-card structure (e.g. Texas Hold'em, Omaha) and should be overridden for variants without community cards (e.g. 5-Card Draw, 7-Card Stud).
+
+### Supported hand rankings (highest to lowest)
+
+| Rank | Name            |
+|------|-----------------|
+| 1    | Royal Flush     |
+| 2    | Straight Flush  |
+| 3    | Four of a Kind  |
+| 4    | Full House      |
+| 5    | Flush           |
+| 6    | Straight        |
+| 7    | Three of a Kind |
+| 8    | Two Pair        |
+| 9    | Pair            |
+| 10   | High Card       |
 
 ## Installation
 
@@ -20,23 +37,70 @@ Run `composer require garak/pokerino`.
 
 ## Usage
 
-Here is an example of a game:
+### Texas Hold'em example
 
 ```php
 <?php
 
 require 'vendor/autoload.php';
 
-use App\Game;   // this is your Game class, extending \Garak\Pokerino\Game
-use App\Player;   // this is your Player class, extending \Garak\Pokerino\Player
+use App\Game;    // your Game class, extending \Garak\Pokerino\Game
+use App\Player;  // your Player class, extending \Garak\Pokerino\Player
 
 $game = new Game();
-$game->addPlayer(new Player('Marty McFly'));
-$game->addPlayer(new Player('Biff Tannen'));
-$game->addPlayer(new Player('Emmett Brown'));
-$game->addPlayer(new Player('Jennifer Parker'));
-$game->deal();  // deal 2 cards to each player
-$game->hands(); // return an array of \Garak\Pokerino\Hand
+$game->join(new Player('Marty McFly'));
+$game->join(new Player('Biff Tannen'));
+$game->join(new Player('Emmett Brown'));
+
+// Deal 2 hole cards to each player + 5 community cards (Texas Hold'em defaults)
+$game->deal();
+
+// Retrieve all hands (player hands first, community hand last)
+$hands = $game->getHands();
+
+// Evaluate a single hand
+$hand = $hands[0];
+echo $hand->getPoint();          // e.g. "Flush"
+echo $hand->getHigh();           // highest relevant card
+echo $hand->getKicker();         // best side card
+echo $hand->getHandStrength();   // numeric rank: 1 (Royal Flush) … 10 (High Card)
+
+// Determine the winner (combines each player's hole cards with community cards)
+$winner = $game->winner();
+echo $winner; // player name
+```
+
+### Other variants
+
+`deal()` accepts custom parameters to support different dealing styles:
+
+```php
+$game->deal(5, 0);  // 5-Card Draw: 5 hole cards, no community cards
+$game->deal(4, 5);  // Omaha: 4 hole cards + 5 community cards
+$game->deal(2, 5);  // Texas Hold'em (default)
+```
+
+> **Note:** `winner()` assumes a community-card structure. For variants without community cards, override it in your `Game` subclass.
+
+### Evaluating a hand directly
+
+```php
+use Garak\Card\Card;
+use Garak\Pokerino\Hand;
+
+$cards = [
+    Card::fromRankSuit('Ac'),
+    Card::fromRankSuit('Kc'),
+    Card::fromRankSuit('Qc'),
+    Card::fromRankSuit('Jc'),
+    Card::fromRankSuit('Tc'),
+    Card::fromRankSuit('2s'),
+    Card::fromRankSuit('7d'),
+];
+
+$hand = new Hand($cards);
+echo $hand->getPoint();        // "Royal Flush"
+echo $hand->getHandStrength(); // 1
 ```
 
 ## Credits

--- a/src/Game.php
+++ b/src/Game.php
@@ -42,9 +42,12 @@ abstract class Game
         return $this->hands;
     }
 
-    public function deal(int $startingHandCount = 2, int $commonCount = 5): void
+    /**
+     * @param array<int, Card>|null $deck Pre-arranged deck (useful for testing). If null, a shuffled deck is used.
+     */
+    public function deal(int $startingHandCount = 2, int $commonCount = 5, ?array $deck = null): void
     {
-        $cards = Card::getDeck(true);
+        $cards = $deck ?? Card::getDeck(true);
         for ($i = 0; $i < $this->players->count(); ++$i) {
             $handCards = [];
             for ($j = 0; $j < $startingHandCount; ++$j) {
@@ -63,5 +66,130 @@ abstract class Game
             }
             $this->hands->add(new Hand($handCards));
         }
+    }
+
+    /**
+     * Determines the winner by combining each player's hole cards with the community cards.
+     * Returns null if no hands have been dealt yet or there are no community cards.
+     */
+    public function winner(): ?Player
+    {
+        $handsCount = $this->hands->count();
+        $playersCount = $this->players->count();
+        if ($handsCount < 2 || 0 === $playersCount) {
+            return null;
+        }
+
+        // Ensure a community hand exists. In the expected setup each player
+        // has a hand and there's one additional community hand (playersCount + 1).
+        // If no community cards are present (e.g. commonCount = 0) or hands were
+        // populated differently, do not attempt to compute a winner here.
+        if ($handsCount !== $playersCount + 1) {
+            return null;
+        }
+
+        // Determine community hand robustly: pick the hand with the largest
+        // number of cards if it is a unique maximum. This avoids assuming the
+        // community hand is always the last element in the collection which
+        // may not hold after merges or external modifications to $this->hands.
+        $handCounts = [];
+        for ($h = 0; $h < $handsCount; ++$h) {
+            $hObj = $this->hands->get($h);
+            $handCounts[$h] = null === $hObj ? 0 :
+                \count($hObj->getCards());
+        }
+
+        if ([] === $handCounts) {
+            return null;
+        }
+        $maxCount = \max($handCounts);
+        // find indices that have the max count
+        $maxIndices = [];
+        foreach ($handCounts as $idx => $c) {
+            if ($c === $maxCount) {
+                $maxIndices[] = $idx;
+            }
+        }
+
+        // require a unique community hand (unique maximum). If ambiguous,
+        // bail out to avoid making wrong assumptions.
+        if (1 !== \count($maxIndices)) {
+            return null;
+        }
+
+        $communityIndex = $maxIndices[0];
+        $communityHand = $this->hands->get($communityIndex);
+        if (null === $communityHand) {
+            return null;
+        }
+        $communityCards = $communityHand->getCards();
+        if ([] === $communityCards) {
+            return null;
+        }
+
+        $bestPlayer = null;
+        $bestStrength = \PHP_INT_MAX; // lower is stronger
+        $bestTie = [];
+
+        // Build ordered list of player hands by iterating all hands and
+        // skipping the community hand. This preserves the relative order of
+        // non-community hands as stored in the collection.
+        $playerHands = [];
+        for ($j = 0; $j < $handsCount; ++$j) {
+            if ($j === $communityIndex) {
+                continue;
+            }
+            $hObj = $this->hands->get($j);
+            if (null === $hObj) {
+                continue;
+            }
+            $playerHands[] = $hObj;
+        }
+
+        if (\count($playerHands) < $playersCount) {
+            // Not enough player hands available
+            return null;
+        }
+
+        for ($i = 0; $i < $playersCount; ++$i) {
+            $playerHand = $playerHands[$i];
+            // Combine hole cards with community cards to form a 7-card hand
+            $combinedCards = \array_merge($playerHand->getCards(), $communityCards);
+            $combined = new Hand($combinedCards);
+            $combined->getPoint();
+
+            $strength = $combined->getHandStrength();
+            $tie = $combined->getTieBreak();
+
+            // Compare: lower strength wins; on tie use lexicographic tie-break vector
+            if ($strength < $bestStrength) {
+                $bestStrength = $strength;
+                $bestTie = $tie;
+                $bestPlayer = $this->players->get($i);
+            } elseif ($strength === $bestStrength) {
+                // lexicographic compare
+                // $bestTie is always initialized as an array
+                $max = \max(\count($tie), \count($bestTie));
+                $cmp = 0;
+                for ($k = 0; $k < $max; ++$k) {
+                    $v1 = $tie[$k] ?? 0;
+                    $v2 = $bestTie[$k] ?? 0;
+                    if ($v1 > $v2) {
+                        $cmp = 1;
+                        break;
+                    }
+                    if ($v1 < $v2) {
+                        $cmp = -1;
+                        break;
+                    }
+                }
+                if (1 === $cmp) {
+                    $bestTie = $tie;
+                    $bestPlayer = $this->players->get($i);
+                }
+            }
+        }
+
+        return $bestPlayer;
     }
 }

--- a/src/Hand.php
+++ b/src/Hand.php
@@ -10,6 +10,11 @@ final class Hand extends BaseHand
     private ?Card $high = null;
 
     private ?Card $kicker = null;
+    /** @var int[] */
+    private array $tieBreak = [];
+
+    private int $handStrength = 10; // defaults to High Card strength
+    private bool $evaluated = false;
 
     public function __construct(array $cards, bool $start = true, ?callable $checking = null, ?callable $sorting = null)
     {
@@ -28,6 +33,9 @@ final class Hand extends BaseHand
         $point = $rank->getPoint();
         $this->high = $rank->getHigh();
         $this->kicker = $rank->getKicker();
+        $this->handStrength = $rank->getHandStrength();
+        $this->tieBreak = $rank->getTieBreak();
+        $this->evaluated = true;
 
         return $point;
     }
@@ -40,5 +48,25 @@ final class Hand extends BaseHand
     public function getKicker(): ?Card
     {
         return $this->kicker;
+    }
+
+    /** @return int[] */
+    public function getTieBreak(): array
+    {
+        return $this->tieBreak;
+    }
+
+    /**
+     * Returns a numeric hand strength: 1 = Royal Flush … 10 = High Card.
+     * Call getPoint() first, or it will be lazily evaluated when needed.
+     */
+    public function getHandStrength(): int
+    {
+        // Lazily evaluate the hand if it has not been evaluated yet.
+        if (!$this->evaluated) {
+            $this->getPoint();
+        }
+
+        return $this->handStrength;
     }
 }

--- a/src/PokerRank.php
+++ b/src/PokerRank.php
@@ -10,18 +10,24 @@ final class PokerRank
 
     private ?Card $kicker = null;
 
+    /** @var int[] */
+    private array $tieBreak = [];
+    private ?string $currentPoint = null;
+
     /**
+     * Standard poker hand ranking (index = strength, lower = stronger).
+     *
      * @var array<int, string>
      */
     private array $points = [
-        '4 of a Kind',
         'Royal Flush',
         'Straight Flush',
-        'Straight',
+        '4 of a Kind',
         'Full House',
+        'Flush',
+        'Straight',
         '3 of a Kind',
         '2 Pair',
-        'Flush',
         '1 Pair',
         'High Card',
     ];
@@ -36,14 +42,14 @@ final class PokerRank
     public function getPoint(): string
     {
         $callbacks = [
-            static fn (array $cards): Rank\RankResult => Rank\FourOfAKindRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\RoyalFlushRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\StraightFlushRank::isPoint($cards),
-            static fn (array $cards): Rank\RankResult => Rank\StraightRank::isPoint($cards),
+            static fn (array $cards): Rank\RankResult => Rank\FourOfAKindRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\FullHouseRank::isPoint($cards),
+            static fn (array $cards): Rank\RankResult => Rank\FlushRank::isPoint($cards),
+            static fn (array $cards): Rank\RankResult => Rank\StraightRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\ThreeOfAKindRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\TwoPairRank::isPoint($cards),
-            static fn (array $cards): Rank\RankResult => Rank\FlushRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\PairRank::isPoint($cards),
             static fn (array $cards): Rank\RankResult => Rank\HighCardRank::isPoint($cards),
         ];
@@ -53,8 +59,12 @@ final class PokerRank
             if ($rank->isPoint()) {
                 $this->high = $rank->getHigh();
                 $this->kicker = $rank->getKicker();
+                $this->currentPoint = $this->points[$key];
 
-                return $this->points[$key];
+                // compute tie-break vector for accurate comparisons
+                $this->tieBreak = $this->computeTieBreak($this->currentPoint);
+
+                return $this->currentPoint;
             }
         }
 
@@ -69,5 +79,267 @@ final class PokerRank
     public function getKicker(): ?Card
     {
         return $this->kicker;
+    }
+
+    /**
+     * Returns the tie-break vector (ordered list of ranks used to compare hands
+     * that have the same category). Lower indices are more significant.
+     * Example: Two Pair => [higherPair, lowerPair, kicker].
+     *
+     * @return int[]
+     */
+    public function getTieBreak(): array
+    {
+        return $this->tieBreak;
+    }
+
+    /**
+     * Compute tie-break vector based on currentPoint and the cards.
+     * Uses CardSorter and rank integers.
+     *
+     * @return int[]
+     */
+    private function computeTieBreak(string $point): array
+    {
+        // helper closures
+        $values = \array_map(static fn (Card $c): int => $c->getRank()->getInt(), $this->cards);
+        // counts map rank => count
+        $counts = [];
+        foreach ($values as $v) {
+            $counts[$v] = ($counts[$v] ?? 0) + 1;
+        }
+        // sort values desc unique
+        $unique = \array_values(\array_unique($values));
+        \rsort($unique);
+
+        // group cards by suit
+        $suits = [];
+        foreach ($this->cards as $card) {
+            $s = $card->getSuit()->getInt();
+            $suits[$s][] = $card;
+        }
+
+        // helper to get highest straight from a set of ranks (ints)
+        $getStraightHigh = static function (array $ranks): ?int {
+            $ranks = \array_values(\array_unique($ranks));
+            \sort($ranks);
+            // normal straight detection
+            $best = null;
+            $seq = 1;
+            $prev = null;
+            for ($i = 0, $n = \count($ranks); $i < $n; ++$i) {
+                $v = $ranks[$i];
+                if ($i > 0 && $v === $prev + 1) {
+                    ++$seq;
+                } else {
+                    $seq = 1;
+                }
+                if ($seq >= 5) {
+                    $best = $v;
+                }
+                $prev = $v;
+            }
+            // check wheel A-2-3-4-5
+            if (\in_array(14, $ranks, true) && \in_array(2, $ranks, true) && \in_array(3, $ranks, true) && \in_array(4, $ranks, true) && \in_array(5, $ranks, true)) {
+                $best = \max($best ?? 0, 5);
+            }
+
+            return $best;
+        };
+
+        switch ($point) {
+            case 'Royal Flush':
+                return [14, 13, 12, 11, 10];
+
+            case 'Straight Flush':
+                // for each suit, find straight high; choose best
+                $bestHigh = 0;
+                foreach ($suits as $s => $cards) {
+                    if (\count($cards) < 5) {
+                        continue;
+                    }
+                    $r = \array_map(static fn (Card $c): int => $c->getRank()->getInt(), $cards);
+                    $h = $getStraightHigh($r);
+                    if (null !== $h && $h > $bestHigh) {
+                        $bestHigh = $h;
+                    }
+                }
+                if ($bestHigh > 0) {
+                    return [$bestHigh];
+                }
+
+                return [];
+
+            case '4 of a Kind':
+                $quad = null;
+                foreach ($counts as $rank => $c) {
+                    if (4 === $c) {
+                        $quad = $rank;
+                        break;
+                    }
+                }
+                // kicker is highest other
+                $kicker = 0;
+                foreach ($unique as $r) {
+                    if ($r !== $quad) {
+                        $kicker = $r;
+                        break;
+                    }
+                }
+                if (null !== $quad) {
+                    return [$quad, $kicker];
+                }
+
+                return [];
+
+            case 'Full House':
+                $trip = 0;
+                $pair = 0;
+                // find highest trip
+                foreach ($unique as $r) {
+                    if (($counts[$r] ?? 0) >= 3) {
+                        $trip = $r;
+                        break;
+                    }
+                }
+                // find highest pair not the trip
+                foreach ($unique as $r) {
+                    if ($r === $trip) {
+                        continue;
+                    }
+                    if (($counts[$r] ?? 0) >= 2) {
+                        $pair = $r;
+                        break;
+                    }
+                }
+                if ($trip > 0) {
+                    return [$trip, $pair];
+                }
+
+                return [];
+
+            case 'Flush':
+                // for each suit with >=5, get top5 ranks and pick lexicographically best
+                $best = [];
+                foreach ($suits as $s => $cards) {
+                    if (\count($cards) < 5) {
+                        continue;
+                    }
+                    \usort($cards, static fn (Card $a, Card $b): int => $b->getRank()->getInt() <=> $a->getRank()->getInt());
+                    $top5 = \array_map(static fn (Card $c): int => $c->getRank()->getInt(), \array_slice($cards, 0, 5));
+                    if ([] === $best) {
+                        $best = $top5;
+                        continue;
+                    }
+                    // lexicographic compare
+                    for ($i = 0; $i < 5; ++$i) {
+                        if ($top5[$i] > $best[$i]) {
+                            $best = $top5;
+                            break;
+                        }
+                        if ($top5[$i] < $best[$i]) {
+                            break;
+                        }
+                    }
+                }
+
+                return $best;
+
+            case 'Straight':
+                $h = $getStraightHigh($values);
+                if (null !== $h && $h > 0) {
+                    return [$h];
+                }
+
+                return [];
+
+            case '3 of a Kind':
+                $trip = 0;
+                foreach ($unique as $r) {
+                    if (($counts[$r] ?? 0) === 3) {
+                        $trip = $r;
+                        break;
+                    }
+                }
+                $kickers = [];
+                foreach ($unique as $r) {
+                    if ($r === $trip) {
+                        continue;
+                    }
+                    $kickers[] = $r;
+                    if (\count($kickers) >= 2) {
+                        break;
+                    }
+                }
+                if ($trip > 0) {
+                    return \array_merge([$trip], $kickers);
+                }
+
+                return [];
+
+            case '2 Pair':
+                $pairs = [];
+                foreach ($unique as $r) {
+                    if (($counts[$r] ?? 0) >= 2) {
+                        $pairs[] = $r;
+                    }
+                }
+                if (\count($pairs) < 2) {
+                    return [];
+                }
+                $kicker = 0;
+                foreach ($unique as $r) {
+                    if (!\in_array($r, $pairs, true)) {
+                        $kicker = $r;
+                        break;
+                    }
+                }
+
+                return [$pairs[0], $pairs[1], $kicker];
+
+            case '1 Pair':
+                // ensure single pair
+                $pairRank = 0;
+                foreach ($unique as $r) {
+                    if (($counts[$r] ?? 0) >= 2) {
+                        $pairRank = $r;
+                        break;
+                    }
+                }
+                $kickers = [];
+                foreach ($unique as $r) {
+                    if ($r === $pairRank) {
+                        continue;
+                    }
+                    $kickers[] = $r;
+                    if (\count($kickers) >= 3) {
+                        break;
+                    }
+                }
+                if ($pairRank > 0) {
+                    return \array_merge([$pairRank], $kickers);
+                }
+
+                return [];
+
+            case 'High Card':
+            default:
+                $top = \array_slice($unique, 0, 5);
+
+                return $top;
+        }
+    }
+
+    /**
+     * Returns a numeric strength for the current hand (call getPoint() first, or it will be evaluated now).
+     * Lower value = stronger hand: 1 = Royal Flush … 10 = High Card.
+     */
+    public function getHandStrength(): int
+    {
+        if (null === $this->currentPoint) {
+            $this->getPoint();
+        }
+
+        return (int) \array_search($this->currentPoint, $this->points, true) + 1;
     }
 }

--- a/src/Rank/FlushRank.php
+++ b/src/Rank/FlushRank.php
@@ -10,21 +10,75 @@ final class FlushRank extends AbstractRank
     {
         $high = null;
         $kicker = null;
-        $counts = \array_count_values(self::getCardsSuits($cards));
-        if (!\in_array(5, $counts, true)) {
-            return new RankResult(false);
-        }
-        CardSorter::sort($cards);
+        // Build counts using int keys to avoid string/int mismatch from array_count_values
+        $counts = [];
         foreach ($cards as $card) {
-            $suitVal = $card->getSuit()->getInt();
-            if (5 === $counts[$suitVal]) {
-                $high = $card;
-                break;
+            $s = $card->getSuit()->getInt();
+            $counts[$s] = ($counts[$s] ?? 0) + 1;
+        }
+
+        // Evaluate all suits that have 5 or more cards and choose the best flush.
+        // This handles the case where callers pass more than 7 cards and multiple
+        // suits may qualify; we must pick the best flush by comparing the top
+        // five suited cards lexicographically.
+        $bestFlush = null; // array of Card
+        foreach ($counts as $suit => $count) {
+            // array_count_values can produce string keys even when values are ints.
+            // Use non-strict comparisons below to avoid type mismatch between
+            // the array key (string) and getSuit()->getInt() (int) while keeping
+            // static analysis happy.
+            if ($count < 5) {
+                continue;
+            }
+
+            // Collect cards of this suit and sort them descending
+            $suitCards = [];
+            foreach ($cards as $card) {
+                if ($card->getSuit()->getInt() === $suit) {
+                    $suitCards[] = $card;
+                }
+            }
+            if ([] === $suitCards) {
+                continue;
+            }
+            CardSorter::sort($suitCards);
+            $topFive = \array_slice($suitCards, 0, 5);
+
+            if (null === $bestFlush) {
+                $bestFlush = $topFive;
+                continue;
+            }
+
+            // Compare topFive with bestFlush lexicographically by rank
+            for ($i = 0; $i < 5; ++$i) {
+                $r1 = $topFive[$i]->getRank()->getInt();
+                $r2 = $bestFlush[$i]->getRank()->getInt();
+                if ($r1 > $r2) {
+                    $bestFlush = $topFive;
+                    break;
+                }
+                if ($r1 < $r2) {
+                    break;
+                }
+                // otherwise equal -> continue to next card
             }
         }
+
+        if (null === $bestFlush) {
+            return new RankResult(false);
+        }
+
+        // The highest card of the flush is the first element. For compatibility
+        // with existing behavior, the kicker is the highest card that is NOT
+        // part of the flush (a side card), so we search the full card set for
+        // the first card of a different suit after sorting.
+        $high = $bestFlush[0];
+        $flushSuit = $high->getSuit()->getInt();
+
+        CardSorter::sort($cards);
+        $kicker = null;
         foreach ($cards as $card) {
-            $suitVal = $card->getSuit()->getInt();
-            if (5 !== $counts[$suitVal]) {
+            if ($card->getSuit()->getInt() !== $flushSuit) {
                 $kicker = $card;
                 break;
             }

--- a/src/Rank/FullHouseRank.php
+++ b/src/Rank/FullHouseRank.php
@@ -17,9 +17,10 @@ final class FullHouseRank extends AbstractRank
             return new RankResult(false);
         }
         CardSorter::sort($cards);
+        // In a Full House the THREE-OF-A-KIND determines the hand value, not the pair
         foreach ($cards as $card) {
             $rank = $card->getRank()->getInt();
-            if (3 === $counts[$rank] || 2 === $counts[$rank]) {
+            if (3 === $counts[$rank]) {
                 $high = $card;
                 break;
             }

--- a/src/Rank/RoyalFlushRank.php
+++ b/src/Rank/RoyalFlushRank.php
@@ -2,37 +2,78 @@
 
 namespace Garak\Pokerino\Rank;
 
+use Garak\Card\Card;
 use Garak\Pokerino\CardSorter;
 
 final class RoyalFlushRank extends AbstractRank
 {
     public static function isPoint(array $cards): RankResult
     {
-        $counts = \array_count_values(self::getCardsSuits($cards));
-        if (!\in_array(5, $counts, true)) {
-            return new RankResult(false);
+        // Build counts using int keys to avoid string/int mismatch from array_count_values
+        $counts = [];
+        foreach ($cards as $card) {
+            $s = $card->getSuit()->getInt();
+            $counts[$s] = ($counts[$s] ?? 0) + 1;
         }
 
-        $high = null;
-        $kicker = null;
-        [
-            'max' => $max,
-            'sequence' => $sequence,
-            'maxSequence' => $maxSequence,
-            'values' => $values,
-            'cardsInStraight' => $cardsInStraight,
-            'cards' => $cards,
-        ] = self::straight($cards);
+        // Evaluate all suits that have 5 or more cards and check for a royal
+        // flush. We prefer any royal flush found; if multiple exist we keep
+        // the one with the best kicker.
+        $bestHigh = null;
+        $bestKicker = null;
 
-        if (4 === \max($sequence, $maxSequence)) {
+        foreach ($counts as $suit => $count) {
+            if ($count < 5) {
+                continue;
+            }
+
+            // Collect cards of this suit
+            $flushCards = \array_values(\array_filter(
+                $cards,
+                static fn (Card $card): bool => $card->getSuit()->getInt() === $suit
+            ));
+            if ([] === $flushCards) {
+                continue;
+            }
+
+            // Evaluate straight among these suited cards
+            [
+                'max' => $max,
+                'sequence' => $sequence,
+                'maxSequence' => $maxSequence,
+                'values' => $values,
+                'cardsInStraight' => $cardsInStraight,
+                'cards' => $flushCards,
+            ] = self::straight($flushCards);
+
+            if (4 !== \max($sequence, $maxSequence)) {
+                continue;
+            }
+
             $maxKey = \array_search($max, $values, true);
-            foreach ($cards as $card) {
+            $high = null;
+            foreach ($flushCards as $card) {
                 if ($card->getRank()->getInt() === $values[$maxKey]) {
                     $high = $card;
                     break;
                 }
             }
+            if (null === $high) {
+                continue;
+            }
+
+            // Ensure the straight is specifically Ten-to-Ace (T-J-Q-K-A).
+            // The `straight()` helper returns the suited straight in
+            // `cardsInStraight` (ascending order). Verify ranks are [10,11,12,13,14].
+            $straightRanks = \array_map(static fn (Card $c): int => $c->getRank()->getInt(), $cardsInStraight);
+            \sort($straightRanks);
+            if ($straightRanks !== [10, 11, 12, 13, 14]) {
+                continue;
+            }
+
+            // Kicker: highest card not in the straight (from all cards, any suit)
             CardSorter::sort($cards);
+            $kicker = null;
             foreach ($cards as $card) {
                 if (!\in_array($card, $cardsInStraight, true)) {
                     $kicker = $card;
@@ -40,11 +81,25 @@ final class RoyalFlushRank extends AbstractRank
                 }
             }
 
-            if ('A' === $cards[0]->getRank()->getValue()) {
-                return new RankResult(true, $high, $kicker);
+            if (null === $bestHigh) {
+                $bestHigh = $high;
+                $bestKicker = $kicker;
+                continue;
+            }
+
+            // Tie-breaker: prefer higher kicker
+            $kickerRank = $kicker?->getRank()->getInt() ?? 0;
+            $bestKickerRank = $bestKicker?->getRank()->getInt() ?? 0;
+            if ($kickerRank > $bestKickerRank) {
+                $bestHigh = $high;
+                $bestKicker = $kicker;
             }
         }
 
-        return new RankResult(false);
+        if (null === $bestHigh) {
+            return new RankResult(false);
+        }
+
+        return new RankResult(true, $bestHigh, $bestKicker);
     }
 }

--- a/src/Rank/StraightFlushRank.php
+++ b/src/Rank/StraightFlushRank.php
@@ -2,36 +2,83 @@
 
 namespace Garak\Pokerino\Rank;
 
+use Garak\Card\Card;
 use Garak\Pokerino\CardSorter;
 
 final class StraightFlushRank extends AbstractRank
 {
     public static function isPoint(array $cards): RankResult
     {
-        $counts = \array_count_values(self::getCardsSuits($cards));
-        if (!\in_array(5, $counts, true)) {
-            return new RankResult(false);
+        // Build counts using int keys to avoid string/int mismatch from array_count_values
+        $counts = [];
+        foreach ($cards as $card) {
+            $s = $card->getSuit()->getInt();
+            $counts[$s] = ($counts[$s] ?? 0) + 1;
         }
 
-        $high = null;
-        $kicker = null;
-        [
-            'max' => $max,
-            'sequence' => $sequence,
-            'maxSequence' => $maxSequence,
-            'values' => $values,
-            'cardsInStraight' => $cardsInStraight,
-            'cards' => $cards,
-        ] = self::straight($cards);
+        // Evaluate all suits that have 5 or more cards and choose the best
+        // straight flush (highest straight among suited cards).
+        $bestHigh = null;
+        $bestKicker = null;
+        $bestHighRank = 0;
 
-        if (4 === \max($sequence, $maxSequence)) {
-            $maxKey = \array_search($max, $values, true);
-            foreach ($cards as $card) {
-                if ($card->getRank()->getInt() === $values[$maxKey]) {
-                    $high = $card;
-                    break;
+        foreach ($counts as $suit => $count) {
+            if ($count < 5) {
+                continue;
+            }
+
+            // Collect cards of this suit
+            $flushCards = \array_values(\array_filter(
+                $cards,
+                static fn (Card $card): bool => $card->getSuit()->getInt() === $suit
+            ));
+            if ([] === $flushCards) {
+                continue;
+            }
+
+            // Evaluate straight among these suited cards
+            [
+                'max' => $max,
+                'sequence' => $sequence,
+                'maxSequence' => $maxSequence,
+                'values' => $values,
+                'cardsInStraight' => $cardsInStraight,
+                'cards' => $flushCards,
+            ] = self::straight($flushCards);
+
+            $isStraight = 4 === \max($sequence, $maxSequence);
+
+            $high = null;
+            $kicker = null;
+
+            if ($isStraight) {
+                $maxKey = \array_search($max, $values, true);
+                foreach ($flushCards as $card) {
+                    if ($card->getRank()->getInt() === $values[$maxKey]) {
+                        $high = $card;
+                        break;
+                    }
+                }
+            } else {
+                // Check Ace-low straight (wheel) among suited cards: A-2-3-4-5
+                $first = \current($values);
+                if (\in_array(14, $values, true) && 2 === $first && 3 === \max($sequence, $maxSequence) && \in_array(5, $values, true) && \in_array(4, $values, true) && \in_array(3, $values, true)) {
+                    // high is the 5 in the wheel
+                    foreach ($flushCards as $card) {
+                        if (5 === $card->getRank()->getInt()) {
+                            $high = $card;
+                            break;
+                        }
+                    }
+                    // prepare cardsInStraight already contains the straight suited cards
                 }
             }
+
+            if (null === $high) {
+                continue;
+            }
+
+            // Kicker: highest card not in the straight (from all cards, any suit)
             CardSorter::sort($cards);
             foreach ($cards as $card) {
                 if (!\in_array($card, $cardsInStraight, true)) {
@@ -40,9 +87,26 @@ final class StraightFlushRank extends AbstractRank
                 }
             }
 
-            return new RankResult(true, $high, $kicker);
+            $highRank = $high->getRank()->getInt();
+            if ($highRank > $bestHighRank) {
+                $bestHighRank = $highRank;
+                $bestHigh = $high;
+                $bestKicker = $kicker;
+            } elseif ($highRank === $bestHighRank) {
+                // tie-break by kicker
+                $kickerRank = $kicker?->getRank()->getInt() ?? 0;
+                $bestKickerRank = $bestKicker?->getRank()->getInt() ?? 0;
+                if ($kickerRank > $bestKickerRank) {
+                    $bestHigh = $high;
+                    $bestKicker = $kicker;
+                }
+            }
         }
 
-        return new RankResult(false);
+        if (null === $bestHigh) {
+            return new RankResult(false);
+        }
+
+        return new RankResult(true, $bestHigh, $bestKicker);
     }
 }

--- a/tests/GameTest.php
+++ b/tests/GameTest.php
@@ -2,6 +2,7 @@
 
 namespace Garak\Pokerino\Tests;
 
+use Garak\Card\Card;
 use Garak\Pokerino\Test\StubGame;
 use Garak\Pokerino\Test\StubPlayer;
 use PHPUnit\Framework\TestCase;
@@ -34,5 +35,101 @@ final class GameTest extends TestCase
         $player1 = new StubPlayer('John Doe');
         $game->join($player1);
         $game->join($player1);
+    }
+
+    public function testWinnerNullBeforeDeal(): void
+    {
+        $game = new StubGame();
+        $player1 = new StubPlayer('Alice');
+        $game->join($player1);
+        self::assertNull($game->winner());
+    }
+
+    public function testWinnerReturnsPlayerAfterDeal(): void
+    {
+        $game = new StubGame();
+        $player1 = new StubPlayer('Alice');
+        $player2 = new StubPlayer('Bob');
+        $game->join($player1);
+        $game->join($player2);
+        $game->deal();
+        $winner = $game->winner();
+        self::assertNotNull($winner);
+        self::assertTrue($game->hasPlayer($winner));
+    }
+
+    public function testWinnerWithKnownCards(): void
+    {
+        // Alice: Ac Kc (hole) → with community forms A-K-Q-J-T = Royal Flush
+        // Bob:   2s 3s (hole) → with community forms at best a Straight
+        // Community: Qc Jc Tc 2d 3d
+        $game = new StubGame();
+        $alice = new StubPlayer('Alice');
+        $bob = new StubPlayer('Bob');
+        $game->join($alice);
+        $game->join($bob);
+
+        // Build a fixed deck: Alice's hole, Bob's hole, then community cards, rest can be anything
+        $deck = [
+            Card::fromRankSuit('Ac'), // Alice hole 1
+            Card::fromRankSuit('Kc'), // Alice hole 2
+            Card::fromRankSuit('2s'), // Bob hole 1
+            Card::fromRankSuit('3s'), // Bob hole 2
+            Card::fromRankSuit('Qc'), // community 1
+            Card::fromRankSuit('Jc'), // community 2
+            Card::fromRankSuit('Tc'), // community 3
+            Card::fromRankSuit('2d'), // community 4
+            Card::fromRankSuit('3d'), // community 5
+        ];
+
+        $game->deal(2, 5, $deck);
+        $winner = $game->winner();
+        self::assertSame($alice, $winner, 'Alice should win with a Royal Flush');
+    }
+
+    public function testWinnerWhenCommunityHandIsNotLast(): void
+    {
+        // Same scenario as testWinnerWithKnownCards but move the community hand
+        // to a non-last position in the internal hands collection to ensure
+        // winner() does not assume the community hand is the last element.
+        $game = new StubGame();
+        $alice = new StubPlayer('Alice');
+        $bob = new StubPlayer('Bob');
+        $game->join($alice);
+        $game->join($bob);
+
+        $deck = [
+            Card::fromRankSuit('Ac'),
+            Card::fromRankSuit('Kc'),
+            Card::fromRankSuit('2s'),
+            Card::fromRankSuit('3s'),
+            Card::fromRankSuit('Qc'),
+            Card::fromRankSuit('Jc'),
+            Card::fromRankSuit('Tc'),
+            Card::fromRankSuit('2d'),
+            Card::fromRankSuit('3d'),
+        ];
+
+        $game->deal(2, 5, $deck);
+
+        // Reorder hands so community hand is not the last element
+        $hands = $game->getHands()->toArray();
+        $community = \array_pop($hands);
+        // insert community at position 1 (middle)
+        \array_splice($hands, 1, 0, [$community]);
+
+        // replace internal collection via reflection (find the property in the
+        // class hierarchy since $hands is declared in the abstract parent)
+        $rc = new \ReflectionObject($game);
+        while (!$rc->hasProperty('hands')) {
+            $parent = $rc->getParentClass();
+            \assert(false !== $parent);
+            $rc = $parent;
+        }
+        $prop = $rc->getProperty('hands');
+        $prop->setValue($game, new \Doctrine\Common\Collections\ArrayCollection($hands));
+
+        $winner = $game->winner();
+        self::assertSame($alice, $winner, 'Alice should still win when community hand is not last');
     }
 }

--- a/tests/HandTest.php
+++ b/tests/HandTest.php
@@ -139,7 +139,8 @@ final class HandTest extends TestCase
                     Card::fromRankSuit('Kc'),
                 ],
                 'point' => 'Full House',
-                'high' => '7h',
+                // $high = highest card of the three-of-a-kind (6s), which determines Full House value
+                'high' => '6s',
                 'kicker' => 'Kc',
             ],
             'straight' => [

--- a/tests/PokerRankTest.php
+++ b/tests/PokerRankTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Garak\Pokerino\Tests;
+
+use Garak\Card\Card;
+use Garak\Pokerino\PokerRank;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PokerRankTest extends TestCase
+{
+    /**
+     * @param string[] $ranks
+     */
+    #[DataProvider('strengthProvider')]
+    public function testHandStrength(array $ranks, int $expected, string $message): void
+    {
+        $cards = [];
+        foreach ($ranks as $r) {
+            $cards[] = Card::fromRankSuit($r);
+        }
+
+        $rank = new PokerRank($cards);
+        $strength = $rank->getHandStrength();
+
+        self::assertSame($expected, $strength, $message);
+    }
+
+    /**
+     * @return array<string, array{array<string>,int,string}>
+     */
+    public static function strengthProvider(): array
+    {
+        return [
+            // Royal Flush (should be strength 1)
+            'royal-flush' => [
+                ['Ac', 'Kc', 'Qc', 'Jc', 'Tc', '2d', '3h'],
+                1,
+                'Royal Flush must map to strength 1',
+            ],
+            // Full House (should be strength 4)
+            'full-house' => [
+                ['9c', '9d', '9h', '2s', '2d', '3h', '4c'],
+                4,
+                'Full House must map to strength 4',
+            ],
+            // High Card (should be strength 10)
+            'high-card' => [
+                ['Ac', 'Kd', '9h', '7s', '4c', '2d', '6h'],
+                10,
+                'High Card must map to strength 10',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Flush/Straight Flush/Royal Flush now correctly detected when 6 or 7 cards of the same suit are present (previously required exactly 5). Straight Flush and Royal Flush also filter to flush-suit cards before running straight detection, preventing mixed-suit false positives.
- Fix hand priority order to match standard poker ranking (Flush was ranked below Two Pair; Straight above Full House).
- Fix Full House $high to always point to the three-of-a-kind card, which determines the hand's value, not the pair.
- Add Game::winner() to compare players' 7-card hands (hole + community) and return the winning Player.
- Add PokerRank::getHandStrength() / Hand::getHandStrength() returning a numeric rank (1 = Royal Flush … 10 = High Card) for hand comparison.
- Allow Game::deal() to accept an optional pre-arranged deck for testing.